### PR TITLE
fix: docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ If you want to connect specific frameworks see [Flask integration](./docs/flask.
 
 ### Install module
 
-Install `hawkcatcher` from PyPI.
+Install `hawk_python_sdk` from PyPI.
 
 ```shell
-$ pip install hawkcatcher
+$ pip install hawk_python_sdk
 ```
 
 Import Catcher module to your project.
 
 ```python
-from hawkcatcher import Hawk
+from hawk_python_sdk import Hawk
 ```
 
 Then enable Hawk Catcher with your token and domain.
@@ -106,7 +106,7 @@ Parameters:
 
 ## Requirements
 
-- Python \>= 3.9
+- Python \>= 3.12
 - requests
 
 ## Links

--- a/docs/fastapi.md
+++ b/docs/fastapi.md
@@ -1,26 +1,26 @@
-# Flask integration
+# FastAPI integration
 
 This extension adds support for the [FastAPI](https://fastapi.tiangolo.com/) web framework.
 
 ## Installation
 
 ```bash
-pip install hawkcatcher[fastapi]
+pip install hawk_python_sdk[fastapi]
 ```
 
 import Catcher module to your project.
 
 ```python
-from hawkcatcher.modules.fastapi import HawkFastapi
+from hawk_python_sdk.modules.fastapi import HawkFastapi
 ```
 
 ```python
 app = FastAPI()
 
-hawk = HawkFastapi(
+hawk = HawkFastapi({
     'app_instance': app,
     'token': '1234567-abcd-8901-efgh-123456789012'
-)
+})
 ```
 
 Now all global fastapi errors would be sent to Hawk.
@@ -60,10 +60,10 @@ To init Hawk Catcher just pass a project token and FastAPI app instance.
 ```python
 app = FastAPI()
 
-hawk = HawkFastapi(
+hawk = HawkFastapi({
     'app_instance': app,
     'token': '1234567-abcd-8901-efgh-123456789012'
-)
+})
 ```
 
 ### Additional params

--- a/docs/flask.md
+++ b/docs/flask.md
@@ -5,13 +5,13 @@ This extension adds support for the [Flask](http://flask.pocoo.org/) web framewo
 ## Installation
 
 ```bash
-pip install hawkcatcher[flask]
+pip install hawk_python_sdk[flask]
 ```
 
 import Catcher module to your project.
 
 ```python
-from hawkcatcher.modules.flask import HawkFlask
+from hawk_python_sdk.modules.flask import HawkFlask
 ```
 
 ```python


### PR DESCRIPTION
1. Renamed package name from `hawkcatcher` to `hawk_python_sdk`
2. Added braces to init examples
3. Elevated min python version